### PR TITLE
fix(auth): Implement retry logic to fetch user on login and sign up

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -24,8 +24,20 @@ export default function LoginPage() {
     try {
       await AuthService.signInWithEmailAndPassword(email, password);
 
-      //wait 1 seconds to allow the fb to initialize the user profile
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      //try to get user profile for 10 seconds
+      // This is to ensure that the user is logged in before redirecting
+      for (let i = 0; i < 10; i++) {
+        // Check if the user is logged in by fetching the user token
+        const token = await AuthService.getIdToken();
+        if (token) {
+          break; // Exit loop if user is found
+        }
+        console.warn(
+          `Attempt ${i + 1}: Logged in User profile not found yet, retrying...`
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait before retrying
+      }
 
       router.push("/main"); // Redirect to the home page after successful login
     } catch (error) {

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -95,9 +95,22 @@ export default function RegisterPage() {
         userData
       );
 
-      //wait for the user to be created before uploading the files
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      //try to get user profile for 10 seconds
+      // This is to ensure that the user is created and can create documents
+      for (let i = 0; i < 10; i++) {
+        // Check if the user is created by fetching the user profile
+        const token = await AuthService.getIdToken();
+        if (token) {
+          break; // Exit loop if user is found
+        }
+        console.warn(
+          `Attempt ${i + 1}: User profile not found yet, retrying...`
+        );
 
+        await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait before retrying
+      }
+
+      //create documents
       const pfpPath = await StorageService.uploadImage(
         formData.pfpFile!,
         `user-pfps/${uuidv4()}-${formData.pfpFile?.name}`


### PR DESCRIPTION
# Fix Auth Retry Logic Implementation

## Summary
Implements retry logic for user authentication on both login and sign up pages to handle timing issues with Firebase user initialization.

## Changes Made
- **Login Page**: Added retry mechanism to check for user token after sign in
- **Register Page**: Added retry mechanism to ensure user profile is created before proceeding with document creation

## Technical Details
- Retry logic attempts to fetch user token up to 10 times with 1-second intervals
- Added console warnings to track retry attempts for debugging
- Ensures proper user authentication state before redirecting or creating documents