### PR TITLE
Feature/implement metrics card

### DIFF
--- a/src/app/main/analyst/metrics/CategoryDropdown.tsx
+++ b/src/app/main/analyst/metrics/CategoryDropdown.tsx
@@ -1,0 +1,26 @@
+interface Props {
+    selected: string | undefined;
+    onSelect: (value: string | undefined) => void;
+  }
+  
+  const categories = [
+    { label: 'Dentist', value: 'dentist' },
+    { label: 'Dermatological', value: 'dermatological' },
+    { label: 'Pediatric', value: 'pediatric' },
+    { label: 'Surgical', value: 'surgical' },
+    { label: 'General purpose', value: 'general_purpose' },
+  ];
+  
+  export function CategoryDropdown({ selected, onSelect }: Props) {
+    return (
+      <select value={selected ?? ''} onChange={(e) => onSelect(e.target.value || undefined)}  className="text-sm border  rounded">
+        <option value="">Select a category</option>
+        {categories.map((cat) => (
+          <option key={cat.value} value={cat.value}>
+            {cat.label}
+          </option>
+        ))}
+      </select>
+    );
+  }
+  

--- a/src/app/main/analyst/metrics/CityDropdown.tsx
+++ b/src/app/main/analyst/metrics/CityDropdown.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { ClinicService, CityOption } from "@/services/ClinicService";
+
+export function CityDropdown({
+  onSelect,
+  selected,
+}: {
+  onSelect: (value: string) => void;
+  selected?: string;
+}) {
+  const [cities, setCities] = useState<CityOption[]>([]);
+
+  useEffect(() => {
+    ClinicService.getCitiesWithClinics()
+      .then(setCities)
+      .catch(console.error);
+  }, []);
+
+  return (
+    <select
+      value={selected}
+      onChange={(e) => onSelect(e.target.value)}
+      className="border text-sm rounded w-[100]"
+    >
+      <option value="">Select a city</option>
+      {cities.map((city) => (
+        <option key={city.value} value={city.value}>
+          {city.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/app/main/analyst/metrics/Filters.tsx
+++ b/src/app/main/analyst/metrics/Filters.tsx
@@ -28,7 +28,7 @@ export default function Filters() {
 
   const cardsData = [
     {
-      title: 'Clinics that match your filters ',
+      title: 'Clinics that match your filters',
       value: clinicCount !== null ? clinicCount.toString() : 'Cargando...'
     }
   ];

--- a/src/app/main/analyst/metrics/Filters.tsx
+++ b/src/app/main/analyst/metrics/Filters.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { CityDropdown } from './CityDropdown';
+import { CategoryDropdown } from './CategoryDropdown';
+import { ClinicService } from '@/services/ClinicService';
+import SectionCards from './components/MetricsCard';
+
+export default function Filters() {
+  const [selectedCity, setSelectedCity] = useState<string | undefined>();
+  const [selectedCategory, setSelectedCategory] = useState<string | undefined>();
+  const [clinicCount, setClinicCount] = useState<number | null>(null);
+
+  // Cargar conteo total al inicio
+  useEffect(() => {
+    if (!selectedCity && !selectedCategory) {
+      ClinicService.getTotalClinicsCount()
+        .then(setClinicCount)
+        .catch(console.error);
+    }
+  }, [selectedCity, selectedCategory]);
+
+  useEffect(() => {
+    if (selectedCity || selectedCategory) {
+      ClinicService.getClinicsCount({ city: selectedCity, category: selectedCategory })
+        .then(setClinicCount)
+        .catch(console.error);
+    }
+  }, [selectedCity, selectedCategory]);
+
+  const cardsData = [
+    {
+      title: 'Clinics that match your filters ',
+      value: clinicCount !== null ? clinicCount.toString() : 'Cargando...'
+    }
+  ];
+
+  return (
+    <div>
+      <CityDropdown selected={selectedCity} onSelect={setSelectedCity} />
+      <CategoryDropdown selected={selectedCategory} onSelect={setSelectedCategory} />
+      <SectionCards data={cardsData} />
+    </div>
+  );
+}

--- a/src/app/main/analyst/metrics/components/MetricsCard.tsx
+++ b/src/app/main/analyst/metrics/components/MetricsCard.tsx
@@ -1,23 +1,16 @@
-import { TrendingUp, TrendingDown } from "lucide-react";
-
 export interface MetricCardData {
   title: string;
   value: string;
-  trend: string;
-  trendDirection: "up" | "down";
-  trendIcon?: React.ReactNode;
-  footerTitle: string;
-  footerDescription: string;
+  city?: string;
+  category?: string;
 }
 
 interface SectionCardsProps {
-  data?: MetricCardData[];
+  data: MetricCardData[];
 }
 
 export default function SectionCards({ data }: SectionCardsProps) {
-  const cards = data ?? [];
-
-  if (cards.length === 0) {
+  if (data.length === 0) {
     return (
       <div className="w-full py-8 text-center text-gray-500 text-lg">
         There is no data to render.
@@ -27,30 +20,13 @@ export default function SectionCards({ data }: SectionCardsProps) {
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-8 py-8">
-      {cards.map((card, index) => (
+      {data.map((card, index) => (
         <div
           key={index}
           className="w-full bg-white shadow-md border-2 border-gray-300 rounded-xl p-4 relative"
         >
-          <div className="mb-2 text-sm text-gray-500 ">{card.title}</div>
-          <div className="text-2xl font-semibold mb-6 text-gray-900 ">
-            {card.value}
-          </div>
-          <div className="absolute top-4 right-4 flex items-center text-xs border px-2 py-1 rounded-lg gap-1 text-gray-700 border-gray-300  bg-white">
-            {card.trendIcon}
-            {card.trend}
-          </div>
-          <div className="mt-4 text-sm">
-            <div className="flex items-center gap-2 font-medium text-gray-800 ">
-              {card.footerTitle}{" "}
-              {card.trendDirection === "up" ? (
-                <TrendingUp className="w-4 h-4 text-green-500" />
-              ) : (
-                <TrendingDown className="w-4 h-4 text-red-500" />
-              )}
-            </div>
-            <div className="text-gray-500 ">{card.footerDescription}</div>
-          </div>
+          <div className="mb-2 text-sm text-gray-500">{card.title}</div>
+          <div className="text-2xl font-semibold mb-6 text-gray-900">{card.value}</div>
         </div>
       ))}
     </div>

--- a/src/app/main/analyst/metrics/page.tsx
+++ b/src/app/main/analyst/metrics/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import SectionCards from "./components/MetricsCard";
+import Filters from "./Filters";
 import Button from "@/components/Button";
 import { HiOutlineDocumentArrowDown } from "react-icons/hi2";
 import { HiOutlineDocumentText } from "react-icons/hi2";
@@ -9,41 +9,7 @@ import DiseasePrevalenceSection from "./components/DiseasePrevalenceSection";
 import ClinicDemandDashboardSection from "./components/ClinicDemandDashboardSection";
 import SpecialistHeatmapSection from "./components/SpecialistHeatmapSection";
 
-// Mock data - this will be replaced with real API calls later
-const mockMetrics = [
-  {
-    title: "Total Specialists",
-    value: "45",
-    trend: "+5",
-    trendDirection: "up" as const,
-    footerTitle: "From last month",
-    footerDescription: "5 new specialists joined"
-  },
-  {
-    title: "Total Clinics",
-    value: "12",
-    trend: "+2",
-    trendDirection: "up" as const,
-    footerTitle: "From last month",
-    footerDescription: "2 new clinics added"
-  },
-  {
-    title: "Total Patients",
-    value: "1,250",
-    trend: "+150",
-    trendDirection: "up" as const,
-    footerTitle: "From last month",
-    footerDescription: "150 new patients registered"
-  },
-  {
-    title: "Active Cases",
-    value: "320",
-    trend: "+25",
-    trendDirection: "up" as const,
-    footerTitle: "From last month",
-    footerDescription: "25 new active cases"
-  }
-];
+
 
 export default function MetricsPage() {
   const [activeTab, setActiveTab] = useState("specialist");
@@ -151,7 +117,7 @@ export default function MetricsPage() {
     <main className="container mx-auto px-4 py-8">
       {/* Metrics Overview */}
       <section className="mb-8">
-        <SectionCards data={mockMetrics} />
+        <Filters  />
       </section>
 
       {/* Dashboard Navigation and Actions */}

--- a/src/services/ClinicService.ts
+++ b/src/services/ClinicService.ts
@@ -12,6 +12,10 @@ import axios from "axios";
 import { format } from "date-fns";
 import { safeApiCall } from "@/lib/apiUtils";
 
+export type CityOption = {
+  label: string;
+  value: string;
+};
 export class ClinicService {
   static BASE_URL = env.NEXT_PUBLIC_API_URL + "/clinics";
 
@@ -212,4 +216,70 @@ export class ClinicService {
       throw error;
     }
   }
+  static async getClinicsCount({
+    category,
+    city,
+  }: {
+    category?: string;
+    city?: string;
+  }): Promise<number> {
+    let url = "";
+  
+    if (category && city) {
+      url = `${this.BASE_URL}/filter?category=${category}&city=${city}`;
+    } else if (city) {
+      url = `${this.BASE_URL}/city-clinics/${city}`;
+    } else if (category) {
+      url = `${this.BASE_URL}/${category}/count`;
+    } else {
+      throw new Error("Debe indicar al menos ciudad o categoría");
+    }
+  
+    const res = await fetch(url, { cache: "no-store" });
+  
+    if (!res.ok) throw new Error("No se pudo obtener el conteo");
+  
+    const json = await res.json();
+  
+    // Manejar los diferentes formatos posibles
+    if (typeof json.data === "number") {
+      return json.data; // caso filter
+    } else if (json.data && typeof json.data.count === "number") {
+      return json.data.count; // caso city-clinics
+    } else if (typeof json.count === "number") {
+      return json.count; // caso category/count
+    } else {
+      throw new Error("Formato inesperado en la respuesta del backend");
+    }
+  }
+  
+  static async getCitiesWithClinics(): Promise<CityOption[]> {
+    const res = await fetch(`${this.BASE_URL}/cities`, {
+      cache: "no-store",
+    });
+
+    if (!res.ok) throw new Error("Error fetching cities");
+
+    const json = await res.json();
+    if (json.data) {
+      return json.data.count ?? json.data;
+    }
+    
+    return json.count ?? 0;
+    
+  }
+  static async getTotalClinicsCount(): Promise<number> {
+    const url = `${this.BASE_URL}/clinics-count`;
+  
+    const res = await fetch(url, { cache: "no-store" });
+  
+    if (!res.ok) throw new Error("No se pudo obtener el conteo total de clínicas");
+  
+    const json = await res.json();
+  
+    // Tu backend devuelve el count directamente en data, ej:
+    // { success: true, message: "...", data: 123 }
+    return json.data;
+  }
+  
 }

--- a/src/services/ClinicService.ts
+++ b/src/services/ClinicService.ts
@@ -232,7 +232,7 @@ export class ClinicService {
     } else if (category) {
       url = `${this.BASE_URL}/${category}/count`;
     } else {
-      throw new Error("Debe indicar al menos ciudad o categoría");
+      throw new Error("You must specify at least city or category");
     }
   
     const res = await fetch(url, { cache: "no-store" });

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -87,4 +87,5 @@ export class UserService {
       throw error;
     }
   }
+  
 }


### PR DESCRIPTION


### **Pull Request: Add Filters for Clinics by City and Category with Dynamic Metric Cards**

#### **Description**

This PR introduces a filtering feature for clinics by **city** and **category**, allowing users to view real-time counts of clinics that match their selected criteria. It includes:

* A new `Filters` component that handles dropdown selections and data fetching.
* Integration with the `ClinicService` to fetch counts based on:

  * city only
  * category only
  * both city and category
  * no filters (shows total clinics)
* Refactoring of `SectionCards` to become a purely presentational component that receives filtered data.
* UX improvements: filters are displayed above the metric cards, and counts update dynamically as filters change.

#### **Testing**

* ✅ Tested dropdown interaction and dynamic updates of clinic counts.
* ✅ Verified fallback to total clinics when no filters are applied.
* ✅ Checked edge cases (e.g. no results, invalid combinations).

#### **Note**

The backend returns different response structures depending on the endpoint, so the service layer handles normalization accordingly.

---


<img width="1504" alt="Screenshot 2025-06-08 at 9 19 45 p m" src="https://github.com/user-attachments/assets/cc1f4372-270f-4971-885f-ff6b4f2a8674" />
<img width="1510" alt="Screenshot 2025-06-08 at 9 19 57 p m" src="https://github.com/user-attachments/assets/b775583e-3993-4d2d-81ad-c2677c66c1df" />
